### PR TITLE
Support issue & pull request body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - "8"
+notifications:
+  disabled: true

--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@ A [Probot](https://github.com/probot/probot) extension to add message attachment
 ## Usage
 
 ```js
-const attachments = require('probot-attachments');
+const attachments = require('probot-attachments')
 
-// where `context` is a Probot `Context`
-await attachments(context).add({
-  'title': 'Hello World',
-  'title_link': 'https://example.com/hello',
-})
+module.exports = robot => {
+  const events = ['issues.opened', 'pull_request.opened', 'issue_comment.created']
+  robot.on(events, context => {
+    return attachments(context).add({
+      'title': 'Hello World',
+      'title_link': 'https://example.com/hello'
+    })
+  })
+}
 ```
 
 ## Example

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ const template = require('./template')
 
 const attachTo = {
   issue: (context, content) => {
-    const body = context.payload.issue.body + '\n\n' + content.join('\n')
+    const { issue, pull_request: pr } = context.payload
+    const body = (issue || pr).body + '\n\n' + content.join('\n')
     const params = context.issue({body})
     return context.github.issues.edit(params)
   },

--- a/index.js
+++ b/index.js
@@ -1,16 +1,27 @@
 const template = require('./template')
 
+const attachTo = {
+  issue: (context, content) => {
+    const body = context.payload.issue.body + '\n\n' + content.join('\n')
+    const params = context.issue({body})
+    return context.github.issues.edit(params)
+  },
+
+  comment: (context, content) => {
+    const body = context.payload.comment.body + '\n\n' + content.join('\n')
+    const id = context.payload.comment.id
+    const params = context.repo({id, body})
+    return context.github.issues.editComment(params)
+  }
+}
+
 module.exports = function attachments (context) {
-  const {owner, repo} = context.repo()
-  const id = context.payload.comment.id
-  const github = context.github
-  let body = context.payload.comment.body
+  const attach = context.payload.comment ? attachTo.comment : attachTo.issue
 
   return {
     async add (attachments) {
-      const rendered = [].concat(attachments).map(attachment => template(attachment))
-      body += '\n\n' + rendered.join('\n')
-      return github.issues.editComment({owner, repo, id, body})
+      const content = [].concat(attachments).map(attachment => template(attachment))
+      return attach(context, content)
     }
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -112,4 +112,54 @@ describe('attachment', () => {
       })
     })
   })
+
+  describe('on a pull request', () => {
+    beforeEach(() => {
+      event = {
+        payload: {
+          pull_request: {
+            number: 44,
+            body: 'original post'
+          },
+          repository: {
+            owner: {login: 'foo'},
+            name: 'bar'
+          },
+          installation: {id: 1}
+        }
+      }
+
+      context = new Context(event, github)
+    })
+
+    test('adds a single attachment', async () => {
+      await attachments(context).add({
+        title: 'Hello World',
+        title_link: 'https://example.com'
+      })
+
+      expect(github.issues.edit).toHaveBeenCalledWith({
+        owner: 'foo',
+        repo: 'bar',
+        number: 44,
+        body: 'original post\n\n<blockquote><div><strong><a href="https://example.com">Hello World</a></strong></div></blockquote>'
+      })
+    })
+
+    test('adds multiple attachments', async () => {
+      await attachments(context).add([
+        {title: 'Hello World', title_link: 'https://example.com/hello'},
+        {title: 'Goodbye World', title_link: 'https://example.com/goodbye'}
+      ])
+
+      expect(github.issues.edit).toHaveBeenCalledWith({
+        owner: 'foo',
+        repo: 'bar',
+        number: 44,
+        body: 'original post\n\n' +
+          '<blockquote><div><strong><a href="https://example.com/hello">Hello World</a></strong></div></blockquote>\n' +
+          '<blockquote><div><strong><a href="https://example.com/goodbye">Goodbye World</a></strong></div></blockquote>'
+      })
+    })
+  })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,200 +7,109 @@ describe('attachment', () => {
   beforeEach(() => {
     github = {
       issues: {
+        edit: jest.fn(),
         editComment: jest.fn()
       }
     }
-
-    event = {
-      payload: {
-        comment: {
-          id: 42,
-          body: 'original post'
-        },
-        repository: {
-          owner: {login: 'foo'},
-          name: 'bar'
-        },
-        installation: {id: 1}
-      }
-    }
-
-    context = new Context(event, github)
   })
 
-  describe('on a comment without attachments', () => {
+  describe('on a comment', () => {
     beforeEach(() => {
-      // github.issues.get.andReturn(Promise.resolve({
-      //   data: {body: 'original post'}
-      // }))
+      event = {
+        payload: {
+          comment: {
+            id: 42,
+            body: 'original post'
+          },
+          repository: {
+            owner: {login: 'foo'},
+            name: 'bar'
+          },
+          installation: {id: 1}
+        }
+      }
+
+      context = new Context(event, github)
     })
 
-    describe('add', () => {
-      test('adds a single attachment', async () => {
-        await attachments(context).add({
-          title: 'Hello World',
-          title_link: 'https://example.com'
-        })
-
-        expect(github.issues.editComment).toHaveBeenCalledWith({
-          owner: 'foo',
-          repo: 'bar',
-          id: 42,
-          body: 'original post\n\n<blockquote><div><strong><a href="https://example.com">Hello World</a></strong></div></blockquote>'
-        })
+    test('adds a single attachment', async () => {
+      await attachments(context).add({
+        title: 'Hello World',
+        title_link: 'https://example.com'
       })
 
-      test('adds multiple attachments', async () => {
-        await attachments(context).add([
-          {title: 'Hello World', title_link: 'https://example.com/hello'},
-          {title: 'Goodbye World', title_link: 'https://example.com/goodbye'}
-        ])
-
-        expect(github.issues.editComment).toHaveBeenCalledWith({
-          owner: 'foo',
-          repo: 'bar',
-          id: 42,
-          body: 'original post\n\n' +
-            '<blockquote><div><strong><a href="https://example.com/hello">Hello World</a></strong></div></blockquote>\n' +
-            '<blockquote><div><strong><a href="https://example.com/goodbye">Goodbye World</a></strong></div></blockquote>'
-        })
+      expect(github.issues.editComment).toHaveBeenCalledWith({
+        owner: 'foo',
+        repo: 'bar',
+        id: 42,
+        body: 'original post\n\n<blockquote><div><strong><a href="https://example.com">Hello World</a></strong></div></blockquote>'
       })
     })
 
-    // describe('get', () => {
-    //   it('returns null', async () => {
-    //     expect(await attachments(context).get('key')).toEqual(null)
-    //   })
-    //
-    //   it('returns null without key', async () => {
-    //     expect(await attachments(context).get()).toEqual(null)
-    //   })
-    // })
+    test('adds multiple attachments', async () => {
+      await attachments(context).add([
+        {title: 'Hello World', title_link: 'https://example.com/hello'},
+        {title: 'Goodbye World', title_link: 'https://example.com/goodbye'}
+      ])
+
+      expect(github.issues.editComment).toHaveBeenCalledWith({
+        owner: 'foo',
+        repo: 'bar',
+        id: 42,
+        body: 'original post\n\n' +
+          '<blockquote><div><strong><a href="https://example.com/hello">Hello World</a></strong></div></blockquote>\n' +
+          '<blockquote><div><strong><a href="https://example.com/goodbye">Goodbye World</a></strong></div></blockquote>'
+      })
+    })
   })
 
-  // describe('on issue with existing attachments', () => {
-  //   beforeEach(() => {
-  //     // github.issues.get.andReturn(Promise.resolve({
-  //     //   data: {body: 'original post\n\n<!-- probot = {"1":{"key":"value"}} -->'}
-  //     // }))
-  //   })
-  //
-  //   describe('set', () => {
-  //     it('sets new attachments', async () => {
-  //       await attachments(context).set('hello', 'world')
-  //
-  //       expect(github.issues.edit).toHaveBeenCalledWith({
-  //         owner: 'foo',
-  //         repo: 'bar',
-  //         number: 42,
-  //         body: 'original post\n\n<!-- probot = {"1":{"key":"value","hello":"world"}} -->'
-  //       })
-  //     })
-  //
-  //     it('overwrites exiting attachments', async () => {
-  //       await attachments(context).set('key', 'new value')
-  //
-  //       expect(github.issues.edit).toHaveBeenCalledWith({
-  //         owner: 'foo',
-  //         repo: 'bar',
-  //         number: 42,
-  //         body: 'original post\n\n<!-- probot = {"1":{"key":"new value"}} -->'
-  //       })
-  //     })
-  //
-  //     it('merges object with existing attachments', async () => {
-  //       await attachments(context).set({hello: 'world'})
-  //
-  //       expect(github.issues.edit).toHaveBeenCalledWith({
-  //         owner: 'foo',
-  //         repo: 'bar',
-  //         number: 42,
-  //         body: 'original post\n\n<!-- probot = {"1":{"key":"value","hello":"world"}} -->'
-  //       })
-  //     })
-  //   })
-  //
-  //   describe('get', () => {
-  //     it('returns value', async () => {
-  //       expect(await attachments(context).get('key')).toEqual('value')
-  //     })
-  //
-  //     it('returns null for unknown key', async () => {
-  //       expect(await attachments(context).get('unknown')).toEqual(null)
-  //     })
-  //   })
-  // })
-  //
-  // describe('on issue with attachments for a different installation', () => {
-  //   beforeEach(() => {
-  //     // github.issues.get.andReturn(Promise.resolve({
-  //     //   data: {body: 'original post\n\n<!-- probot = {"2":{"key":"value"}} -->'}
-  //     // }))
-  //   })
-  //
-  //   describe('set', () => {
-  //     it('sets new attachments', async () => {
-  //       await attachments(context).set('hello', 'world')
-  //
-  //       expect(github.issues.edit).toHaveBeenCalledWith({
-  //         owner: 'foo',
-  //         repo: 'bar',
-  //         number: 42,
-  //         body: 'original post\n\n<!-- probot = {"1":{"hello":"world"},"2":{"key":"value"}} -->'
-  //       })
-  //     })
-  //
-  //     it('sets an object', async () => {
-  //       await attachments(context).set({hello: 'world'})
-  //
-  //       expect(github.issues.edit).toHaveBeenCalledWith({
-  //         owner: 'foo',
-  //         repo: 'bar',
-  //         number: 42,
-  //         body: 'original post\n\n<!-- probot = {"1":{"hello":"world"},"2":{"key":"value"}} -->'
-  //       })
-  //     })
-  //   })
-  //
-  //   describe('get', () => {
-  //     it('returns null for unknown key', async () => {
-  //       expect(await attachments(context).get('unknown')).toEqual(null)
-  //     })
-  //
-  //     it('returns null without a key', async() => {
-  //       expect(await attachments(context).get()).toEqual(null)
-  //     })
-  //   })
-  // })
-  //
-  // describe('when given body in issue params', () => {
-  //   const issue = {
-  //     owner: 'foo',
-  //     repo: 'bar',
-  //     number: 42,
-  //     body: 'hello world\n\n<!-- probot = {"1":{"hello":"world"}} -->'
-  //   }
-  //
-  //   describe('get', () => {
-  //     it('returns the value without an API call', async () => {
-  //       expect(await attachments(context, issue).get('hello')).toEqual('world')
-  //       expect(github.issues.get).toNotHaveBeenCalled()
-  //     })
-  //   })
-  //
-  //   describe('set', () => {
-  //     it('updates the value without an API call', async () => {
-  //       await attachments(context, issue).set('foo', 'bar')
-  //
-  //       expect(github.issues.get).toNotHaveBeenCalled()
-  //
-  //       expect(github.issues.edit).toHaveBeenCalledWith({
-  //         owner: 'foo',
-  //         repo: 'bar',
-  //         number: 42,
-  //         body: 'hello world\n\n<!-- probot = {"1":{"hello":"world","foo":"bar"}} -->'
-  //       })
-  //     })
-  //   })
-  // })
+  describe('on an issue', () => {
+    beforeEach(() => {
+      event = {
+        payload: {
+          issue: {
+            number: 43,
+            body: 'original post'
+          },
+          repository: {
+            owner: {login: 'foo'},
+            name: 'bar'
+          },
+          installation: {id: 1}
+        }
+      }
+
+      context = new Context(event, github)
+    })
+
+    test('adds a single attachment', async () => {
+      await attachments(context).add({
+        title: 'Hello World',
+        title_link: 'https://example.com'
+      })
+
+      expect(github.issues.edit).toHaveBeenCalledWith({
+        owner: 'foo',
+        repo: 'bar',
+        number: 43,
+        body: 'original post\n\n<blockquote><div><strong><a href="https://example.com">Hello World</a></strong></div></blockquote>'
+      })
+    })
+
+    test('adds multiple attachments', async () => {
+      await attachments(context).add([
+        {title: 'Hello World', title_link: 'https://example.com/hello'},
+        {title: 'Goodbye World', title_link: 'https://example.com/goodbye'}
+      ])
+
+      expect(github.issues.edit).toHaveBeenCalledWith({
+        owner: 'foo',
+        repo: 'bar',
+        number: 43,
+        body: 'original post\n\n' +
+          '<blockquote><div><strong><a href="https://example.com/hello">Hello World</a></strong></div></blockquote>\n' +
+          '<blockquote><div><strong><a href="https://example.com/goodbye">Goodbye World</a></strong></div></blockquote>'
+      })
+    })
+  })
 })


### PR DESCRIPTION
This should make it so attachments can be used in response to an issue, PR, or comment event:

```js
const attachments = require('probot-attachments')

module.exports = robot => {
  const events = ['issues.opened', 'pull_request.opened', 'issue_comment.created']
  robot.on(events, context => {
    return attachments(context).add({
      'title': 'Hello World',
      'title_link': 'https://example.com/hello'
    })
  })
}
```

Fixes #1 