### PR TITLE
feat: Support probot@11 or later

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,16 @@
 import { Context } from 'probot';
 
 type attachments = {
-    pretext: string,
-    author_name: string,
-    author_icon: string,
-    title: string,
-    title_link: string,
-    text: string,
-    image_url: string,
-    thumb_url: string,
-    footer: string,
-    footer_icon: string
+    pretext?: string
+    author_name?: string
+    author_icon?: string
+    title?: string
+    title_link?: string
+    text?: string
+    image_url?: string
+    thumb_url?: string
+    footer?: string
+    footer_icon?: string
 }
 
 type attachmentsManagement = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+import { Context } from 'probot';
+
+type attachments = {
+    pretext: string,
+    author_name: string,
+    author_icon: string,
+    title: string,
+    title_link: string,
+    text: string,
+    image_url: string,
+    thumb_url: string,
+    footer: string,
+    footer_icon: string
+}
+
+type attachmentsManagement = {
+    add: (attachments: attachments) => Promise<void>
+}
+
+export default attachments = (_: Context): attachmentsManagement =>  {
+
+}

--- a/index.js
+++ b/index.js
@@ -1,18 +1,32 @@
-const template = require('./template')
+const { Context } = require('probot');
+const template = require('./template');
 
 const attachTo = {
+
+  /**
+   * Update issue body
+   * @param {Context} context 
+   * @param {string} content 
+   * @returns 
+   */
   issue: (context, content) => {
     const { issue, pull_request: pr } = context.payload
     const body = (issue || pr).body + '\n\n' + content.join('\n')
     const params = context.issue({body})
-    return context.github.issues.edit(params)
+    return context.octokit.issues.update(params)
   },
 
+  /**
+   * Update issue comment
+   * @param {Context} context 
+   * @param {string} content 
+   * @returns 
+   */
   comment: (context, content) => {
     const body = context.payload.comment.body + '\n\n' + content.join('\n')
-    const id = context.payload.comment.id
-    const params = context.repo({id, body})
-    return context.github.issues.editComment(params)
+    const comment_id = context.payload.comment.id
+    const params = context.repo({comment_id, body})
+    return context.octokit.issues.updateComment(params)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest && standard"
   },
-  "repository": "github:probot/attachments",
+  "repository": "github:BellCode-Inc/attachments",
   "keywords": [
     "probot",
     "probot-extension"
@@ -19,7 +19,7 @@
   "devDependencies": {
     "jest": "^21.2.1",
     "jsdom": "^11.3.0",
-    "probot": "^6.0.0",
+    "probot": "^11.0.1",
     "standard": "^10.0.3"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest && standard"
   },
-  "repository": "github:BellCode-Inc/attachments",
+  "repository": "github:probot/attachments",
   "keywords": [
     "probot",
     "probot-extension"


### PR DESCRIPTION
### Change

- require probot@^11
- typescript friendly
- use probot@^11 API
  - `github` change to `octokit`
  - `issues.editComment` change to `issues.updateComment`
  - `issues.edit` change to `issues.update`